### PR TITLE
[BUGFIX] Fix thin-redmine not starting after reboot

### DIFF
--- a/recipes/thin.rb
+++ b/recipes/thin.rb
@@ -37,17 +37,6 @@ template "/etc/thin/redmine.yml" do
   notifies :restart, "service[thin-redmine]"
 end
 
-[
-"/var/run/thin",
-"/var/run/redmine"
-].each do |dir|
-  directory dir do
-    user "redmine"
-    group "redmine"
-    recursive true
-  end
-end
-
 service "thin-redmine" do
   supports :status => true, :restart => true, :reload => true
   action [ :enable, :start ]

--- a/templates/default/nginx/upstream_thin.conf
+++ b/templates/default/nginx/upstream_thin.conf
@@ -5,7 +5,7 @@
 upstream redmine_thin {
 <% servers = node['redmine']['thin_servers'].to_i %>
 <% (0...servers).each do |i| %>
-	server unix:/var/run/redmine/thin.<%= i %>.sock max_fails=1 fail_timeout=15s;
+	server unix:/var/run/thin/thin.<%= i %>.sock max_fails=1 fail_timeout=15s;
 <% end -%>
 
 	# see http://jordanhollinger.com/2011/12/19/deploying-with-thin

--- a/templates/default/nginx/upstream_thin.conf
+++ b/templates/default/nginx/upstream_thin.conf
@@ -5,7 +5,7 @@
 upstream redmine_thin {
 <% servers = node['redmine']['thin_servers'].to_i %>
 <% (0...servers).each do |i| %>
-	server unix:/var/run/thin/thin.<%= i %>.sock max_fails=1 fail_timeout=15s;
+	server unix:/var/run/thin/redmine.<%= i %>.sock max_fails=1 fail_timeout=15s;
 <% end -%>
 
 	# see http://jordanhollinger.com/2011/12/19/deploying-with-thin

--- a/templates/default/thin/init.d.erb
+++ b/templates/default/thin/init.d.erb
@@ -25,7 +25,7 @@ check_run_dir() {
 		mkdir /var/run/thin
 	fi
 	chown redmine:redmine /var/run/thin
-	chmod 0755 /var/run/thin
+	chmod 0750 /var/run/thin
 }
 
 case "$1" in

--- a/templates/default/thin/init.d.erb
+++ b/templates/default/thin/init.d.erb
@@ -25,7 +25,7 @@ check_run_dir() {
 		mkdir /var/run/thin
 	fi
 	chown redmine:redmine /var/run/thin
-	chmod 0750 /var/run/thin
+	chmod 0755 /var/run/thin
 }
 
 case "$1" in

--- a/templates/default/thin/init.d.erb
+++ b/templates/default/thin/init.d.erb
@@ -20,14 +20,24 @@ CONFIG_PATH=/etc/thin
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
+check_run_dir() {
+	if [ ! -d /var/run/thin ]; then
+		mkdir /var/run/thin
+	fi
+	chown redmine:redmine /var/run/thin
+	chmod 0755 /var/run/thin
+}
+
 case "$1" in
   start)
+	check_run_dir
 	$DAEMON start --all $CONFIG_PATH
 	;;
   stop)
 	$DAEMON stop --all $CONFIG_PATH
 	;;
   restart|force-reload|reload)
+	check_run_dir
 	$DAEMON restart --all $CONFIG_PATH
 	;;
   *)
@@ -35,5 +45,8 @@ case "$1" in
 	exit 3
 	;;
 esac
+
+
+
 
 :

--- a/templates/default/thin/init.d.erb
+++ b/templates/default/thin/init.d.erb
@@ -45,8 +45,3 @@ case "$1" in
 	exit 3
 	;;
 esac
-
-
-
-
-:

--- a/templates/default/thin/redmine.yml
+++ b/templates/default/thin/redmine.yml
@@ -13,4 +13,4 @@ servers: <%= node['redmine']['thin_servers'] %>
 daemonize: true
 onebyone: true
 chdir: <%= node['redmine']['deploy_to'] %>/current
-socket: /var/run/thin/thin.sock
+socket: /var/run/thin/redmine.sock

--- a/templates/default/thin/redmine.yml
+++ b/templates/default/thin/redmine.yml
@@ -1,4 +1,4 @@
---- 
+---
 pid: /var/run/thin/redmine.pid
 group: redmine
 timeout: 30
@@ -13,4 +13,4 @@ servers: <%= node['redmine']['thin_servers'] %>
 daemonize: true
 onebyone: true
 chdir: <%= node['redmine']['deploy_to'] %>/current
-socket: /var/run/redmine/thin.sock
+socket: /var/run/thin/thin.sock


### PR DESCRIPTION
`thin` puts its PID files in `/var/run/thin`. This directory
is created with correct permissions ( `redmine:redmine`)
by chef client, but gone after reboot.

In that situation, `thin-redmine` can't start, because it
can't read its old PID files (although the error is about
deletion?).

As countermeasure, let the init script create the
`/var/run/thin` directory with correct ownership, similar
to how other services do it.

Fixes: https://forge.typo3.org/issues/80783