### PR TITLE
[TASK] Start nginx before thin

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -235,7 +235,7 @@ end
 # Includes
 ##########################
 
-include_recipe "redmine::thin"
 include_recipe "redmine::nginx"
+include_recipe "redmine::thin"
 include_recipe "redmine::cron"
 include_recipe "redmine::logrotate"


### PR DESCRIPTION
This makes the intergration tests work.

I am not entirely sure, but the wait_until_ready!
function did not block until thin was completely
started. I assume that it is because of
nginx was not yet restarted with the thin backend
so that we were hitting the static default site.

Tests run successful, if we install nginx first
and then thin.